### PR TITLE
✨ APIリクエストを検索クエリをテキストフィールドから渡せるように変更

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -67,6 +67,7 @@
 		"Pretendard",
 		"riverpod",
 		"signoff",
+		"unfocus",
 		"yumemi"
 	]
 }

--- a/lib/presentations/view_model/search_view_model.dart
+++ b/lib/presentations/view_model/search_view_model.dart
@@ -13,11 +13,14 @@ class SearchViewModel extends _$SearchViewModel {
     return null;
   }
 
+  final textInputController = TextEditingController();
+
   Future<void> onTapSearch() async {
     final githubResRepository = ref.watch(githubResRepositoryProvider);
 
-    final res =
-        await githubResRepository.fetch(RequestParam(q: 'flutter animation'));
+    final res = await githubResRepository.fetch(
+      RequestParam(q: textInputController.text),
+    );
     debugPrint('ITEM LENGTH: ${res.items.length}');
 
     state = res;

--- a/lib/presentations/views/search_view.dart
+++ b/lib/presentations/views/search_view.dart
@@ -1,8 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
-import 'package:yumemi_flutter_codecheck/constants/app_sizes.dart';
-import 'package:yumemi_flutter_codecheck/presentations/routes/app_router.dart';
 import 'package:yumemi_flutter_codecheck/presentations/view_model/search_view_model.dart';
 import 'package:yumemi_flutter_codecheck/presentations/views/widgets/view_template.dart';
 
@@ -13,29 +10,40 @@ class SearchView extends ConsumerWidget {
     final pageState = ref.watch(searchViewModelProvider);
     final pageNotifier = ref.read(searchViewModelProvider.notifier);
     return ViewTemplate.primary(
-      body: Column(
-        children: [
-          const Text('this is search view.'),
-          gapH16,
-          FilledButton(
-            onPressed: () {
-              context.push(Routes.detail.path);
-            },
-            child: const Text('to PAGE-2'),
-          ),
-          gapH16,
-          FilledButton(
-            onPressed: () async {
-              await pageNotifier.onTapSearch();
-            },
-            child: const Text('GET'),
-          ),
-          gapH16,
-          Text(
-            pageState != null ? pageState.items.first.owner.avatarUrl : 'NULL',
-          ),
+      appBar: AppBar(
+        title: _textFormField(
+          pageNotifier.textInputController,
+          pageNotifier.onTapSearch,
+        ),
+      ),
+      body: CustomScrollView(
+        slivers: [
+          pageState != null
+              ? SliverList.builder(
+                  itemCount: pageState.items.length,
+                  itemBuilder: (BuildContext context, int index) {
+                    final item = pageState.items[index];
+                    return Text(item.name);
+                  },
+                )
+              : SliverList(
+                  delegate: SliverChildListDelegate([
+                    const SizedBox.shrink(),
+                  ]),
+                ),
         ],
       ),
+    );
+  }
+
+  Widget _textFormField(
+    TextEditingController controller,
+    Future<void> Function() onTap,
+  ) {
+    return TextField(
+      controller: controller,
+      textInputAction: TextInputAction.search,
+      onSubmitted: (_) async => await onTap(),
     );
   }
 }

--- a/lib/presentations/views/widgets/view_template.dart
+++ b/lib/presentations/views/widgets/view_template.dart
@@ -51,11 +51,15 @@ class ViewTemplate extends StatelessWidget {
       show: kDebugMode,
       child: Scaffold(
         appBar: appBar,
-        body: SafeArea(
-          bottom: bottomSafeArea,
-          child: Padding(
-            padding: viewPadding,
-            child: body,
+        body: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: () => FocusScope.of(context).unfocus(),
+          child: SafeArea(
+            bottom: bottomSafeArea,
+            child: Padding(
+              padding: viewPadding,
+              child: body,
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
## チケット
https://www.notion.so/API-f14f1651c0e140c8bfcec1632840adbe?pvs=4
https://www.notion.so/485659b9bd864209a8777cd76dc2e41e?pvs=4
※TSK-24を吸収

## 対応内容
- view_template.dartのアップデート
  - 画面をタップでテキストフィールドのフォーカスを外せるように変更
- テキストフィールドからクエリを渡せるように変更
- 取得したリポジトリの `name` をList表示

## エビデンス
https://github.com/go5go69/yumemi-flutter-codecheck/assets/71274816/4a9c6bdf-eeec-4336-864b-ad0b16f26e29
