### PR TITLE
Feat/tsk 27/update search view UI

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -63,6 +63,7 @@
     },
 	"cSpell.words": [
 		"codecheck",
+		"cupertino",
 		"flavorizr",
 		"Pretendard",
 		"riverpod",

--- a/lib/presentations/models/search_view_state.dart
+++ b/lib/presentations/models/search_view_state.dart
@@ -1,0 +1,12 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:yumemi_flutter_codecheck/domain/models/github_response_model.dart';
+
+part 'search_view_state.freezed.dart';
+
+@freezed
+class SearchViewState with _$SearchViewState {
+  factory SearchViewState({
+    GitHubResponse? response,
+    @Default(false) bool hasFocus,
+  }) = _SearchViewState;
+}

--- a/lib/presentations/models/search_view_state.freezed.dart
+++ b/lib/presentations/models/search_view_state.freezed.dart
@@ -1,0 +1,171 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'search_view_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$SearchViewState {
+  GitHubResponse? get response => throw _privateConstructorUsedError;
+  bool get hasFocus => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $SearchViewStateCopyWith<SearchViewState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SearchViewStateCopyWith<$Res> {
+  factory $SearchViewStateCopyWith(
+          SearchViewState value, $Res Function(SearchViewState) then) =
+      _$SearchViewStateCopyWithImpl<$Res, SearchViewState>;
+  @useResult
+  $Res call({GitHubResponse? response, bool hasFocus});
+
+  $GitHubResponseCopyWith<$Res>? get response;
+}
+
+/// @nodoc
+class _$SearchViewStateCopyWithImpl<$Res, $Val extends SearchViewState>
+    implements $SearchViewStateCopyWith<$Res> {
+  _$SearchViewStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? response = freezed,
+    Object? hasFocus = null,
+  }) {
+    return _then(_value.copyWith(
+      response: freezed == response
+          ? _value.response
+          : response // ignore: cast_nullable_to_non_nullable
+              as GitHubResponse?,
+      hasFocus: null == hasFocus
+          ? _value.hasFocus
+          : hasFocus // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $GitHubResponseCopyWith<$Res>? get response {
+    if (_value.response == null) {
+      return null;
+    }
+
+    return $GitHubResponseCopyWith<$Res>(_value.response!, (value) {
+      return _then(_value.copyWith(response: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$SearchViewStateImplCopyWith<$Res>
+    implements $SearchViewStateCopyWith<$Res> {
+  factory _$$SearchViewStateImplCopyWith(_$SearchViewStateImpl value,
+          $Res Function(_$SearchViewStateImpl) then) =
+      __$$SearchViewStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({GitHubResponse? response, bool hasFocus});
+
+  @override
+  $GitHubResponseCopyWith<$Res>? get response;
+}
+
+/// @nodoc
+class __$$SearchViewStateImplCopyWithImpl<$Res>
+    extends _$SearchViewStateCopyWithImpl<$Res, _$SearchViewStateImpl>
+    implements _$$SearchViewStateImplCopyWith<$Res> {
+  __$$SearchViewStateImplCopyWithImpl(
+      _$SearchViewStateImpl _value, $Res Function(_$SearchViewStateImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? response = freezed,
+    Object? hasFocus = null,
+  }) {
+    return _then(_$SearchViewStateImpl(
+      response: freezed == response
+          ? _value.response
+          : response // ignore: cast_nullable_to_non_nullable
+              as GitHubResponse?,
+      hasFocus: null == hasFocus
+          ? _value.hasFocus
+          : hasFocus // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SearchViewStateImpl implements _SearchViewState {
+  _$SearchViewStateImpl({this.response, this.hasFocus = false});
+
+  @override
+  final GitHubResponse? response;
+  @override
+  @JsonKey()
+  final bool hasFocus;
+
+  @override
+  String toString() {
+    return 'SearchViewState(response: $response, hasFocus: $hasFocus)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SearchViewStateImpl &&
+            (identical(other.response, response) ||
+                other.response == response) &&
+            (identical(other.hasFocus, hasFocus) ||
+                other.hasFocus == hasFocus));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, response, hasFocus);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SearchViewStateImplCopyWith<_$SearchViewStateImpl> get copyWith =>
+      __$$SearchViewStateImplCopyWithImpl<_$SearchViewStateImpl>(
+          this, _$identity);
+}
+
+abstract class _SearchViewState implements SearchViewState {
+  factory _SearchViewState(
+      {final GitHubResponse? response,
+      final bool hasFocus}) = _$SearchViewStateImpl;
+
+  @override
+  GitHubResponse? get response;
+  @override
+  bool get hasFocus;
+  @override
+  @JsonKey(ignore: true)
+  _$$SearchViewStateImplCopyWith<_$SearchViewStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/presentations/view_model/search_view_model.dart
+++ b/lib/presentations/view_model/search_view_model.dart
@@ -3,9 +3,9 @@ import 'package:go_router/go_router.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:yumemi_flutter_codecheck/app/providers/selected_item_provider.dart';
 import 'package:yumemi_flutter_codecheck/app/repository/github_res_repository.dart';
-import 'package:yumemi_flutter_codecheck/domain/models/github_response_model.dart';
 import 'package:yumemi_flutter_codecheck/domain/models/item_model.dart';
 import 'package:yumemi_flutter_codecheck/domain/models/request_param_model.dart';
+import 'package:yumemi_flutter_codecheck/presentations/models/search_view_state.dart';
 import 'package:yumemi_flutter_codecheck/presentations/routes/app_router.dart';
 
 part 'search_view_model.g.dart';
@@ -13,11 +13,17 @@ part 'search_view_model.g.dart';
 @Riverpod(keepAlive: true)
 class SearchViewModel extends _$SearchViewModel {
   @override
-  GitHubResponse? build() {
-    return null;
+  SearchViewState build() {
+    focusNode.addListener(_onFocusChange);
+    return SearchViewState();
   }
 
   final textInputController = TextEditingController();
+  final focusNode = FocusNode();
+
+  void _onFocusChange() {
+    state = state.copyWith(hasFocus: focusNode.hasFocus);
+  }
 
   Future<void> onTapSearch() async {
     final githubResRepository = ref.watch(githubResRepositoryProvider);
@@ -25,9 +31,16 @@ class SearchViewModel extends _$SearchViewModel {
     final res = await githubResRepository.fetch(
       RequestParam(q: textInputController.text),
     );
-    debugPrint('ITEM LENGTH: ${res.items.length}');
 
-    state = res;
+    state = state.copyWith(response: res);
+  }
+
+  void onTapCancel() {
+    if (state.response != null) {
+      state = state.copyWith(response: null);
+    }
+    textInputController.clear();
+    focusNode.unfocus();
   }
 
   void onTapItem(BuildContext context, Item item) {

--- a/lib/presentations/view_model/search_view_model.g.dart
+++ b/lib/presentations/view_model/search_view_model.g.dart
@@ -6,12 +6,12 @@ part of 'search_view_model.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$searchViewModelHash() => r'f6d1028519b8ca322f39ee85682f755ad9d6fb95';
+String _$searchViewModelHash() => r'f3d4ce18b82f30cbe0a30f1ed2d769fce9a427b8';
 
 /// See also [SearchViewModel].
 @ProviderFor(SearchViewModel)
 final searchViewModelProvider =
-    NotifierProvider<SearchViewModel, GitHubResponse?>.internal(
+    NotifierProvider<SearchViewModel, SearchViewState>.internal(
   SearchViewModel.new,
   name: r'searchViewModelProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
@@ -21,6 +21,6 @@ final searchViewModelProvider =
   allTransitiveDependencies: null,
 );
 
-typedef _$SearchViewModel = Notifier<GitHubResponse?>;
+typedef _$SearchViewModel = Notifier<SearchViewState>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/presentations/views/search_view.dart
+++ b/lib/presentations/views/search_view.dart
@@ -130,7 +130,7 @@ class SearchView extends ConsumerWidget {
             onSubmitted: (_) async => await onTapSearch(),
           ),
         ),
-        hasFocus
+        hasFocus || controller.text.isNotEmpty
             ? InkWell(
                 borderRadius: BorderRadius.circular(Sizes.p8),
                 onTap: () => onTapCancel(),

--- a/lib/presentations/views/search_view.dart
+++ b/lib/presentations/views/search_view.dart
@@ -1,8 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yumemi_flutter_codecheck/constants/app_sizes.dart';
+import 'package:yumemi_flutter_codecheck/domain/models/item_model.dart';
 import 'package:yumemi_flutter_codecheck/presentations/view_model/search_view_model.dart';
+import 'package:yumemi_flutter_codecheck/presentations/views/widgets/item_card.dart';
 import 'package:yumemi_flutter_codecheck/presentations/views/widgets/view_template.dart';
+import 'package:yumemi_flutter_codecheck/themes/app_color_scheme.dart';
+import 'package:yumemi_flutter_codecheck/themes/app_text_theme.dart';
 
 class SearchView extends ConsumerWidget {
   const SearchView({super.key});
@@ -11,46 +15,173 @@ class SearchView extends ConsumerWidget {
     final pageState = ref.watch(searchViewModelProvider);
     final pageNotifier = ref.read(searchViewModelProvider.notifier);
     return ViewTemplate.primary(
-      appBar: AppBar(
-        title: _textFormField(
-          pageNotifier.textInputController,
-          pageNotifier.onTapSearch,
-        ),
-      ),
       body: CustomScrollView(
+        // コンテンツの高さがScrollViewを超えた時のみスクロールするようにする
+        physics: const BouncingScrollPhysics(),
         slivers: [
-          pageState != null
-              ? SliverList.builder(
-                  itemCount: pageState.items.length,
-                  itemBuilder: (BuildContext context, int index) {
-                    final item = pageState.items[index];
-                    return InkWell(
-                      onTap: () => pageNotifier.onTapItem(context, item),
-                      child: Container(
-                        padding: const EdgeInsets.all(Sizes.p12),
-                        child: Text(item.name),
-                      ),
-                    );
-                  },
-                )
-              : SliverList(
-                  delegate: SliverChildListDelegate([
-                    const SizedBox.shrink(),
-                  ]),
-                ),
+          // 画面タイトル
+          _appBarTitle(),
+
+          // 検索ウィンドウ
+          _appBarSearchWindow(
+            controller: pageNotifier.textInputController,
+            focusNode: pageNotifier.focusNode,
+            hasFocus: pageState.hasFocus,
+            onTapSearch: pageNotifier.onTapSearch,
+            onTapCancel: pageNotifier.onTapCancel,
+          ),
+
+          // 検索でヒットした件数
+          _appBarResultCount(
+            context: context,
+            hasResult: pageState.response != null,
+            count: pageState.response?.totalCount,
+          ),
+
+          pageState.response != null
+              ? pageState.response!.items.isNotEmpty
+                  // itemsが1件以上の場合
+                  ? _contentHasResult(
+                      pageState.response!.items,
+                      pageNotifier.onTapItem,
+                    )
+                  // itemsが0件の場合
+                  : _contentNoneResult()
+              // 検索前
+              : _contentDefault()
         ],
       ),
     );
   }
 
-  Widget _textFormField(
+  // TODO: <HIGH> 以下、別ファイルに定義するか検討
+
+  Widget _appBarTitle() {
+    return const SliverAppBar(
+      flexibleSpace: FlexibleSpaceBar(
+        centerTitle: false,
+        title: Text('Discover'),
+        titlePadding: EdgeInsets.zero,
+      ),
+    );
+  }
+
+  Widget _appBarSearchWindow({
+    required TextEditingController controller,
+    required FocusNode focusNode,
+    required bool hasFocus,
+    required Future<void> Function() onTapSearch,
+    required void Function() onTapCancel,
+  }) {
+    return SliverAppBar(
+      pinned: true,
+      floating: true,
+      toolbarHeight: kToolbarHeight + Sizes.p8,
+      flexibleSpace: FlexibleSpaceBar(
+        background: _searchWindow(
+          controller,
+          focusNode,
+          hasFocus,
+          onTapSearch,
+          onTapCancel,
+        ),
+      ),
+    );
+  }
+
+  Widget _appBarResultCount({
+    required BuildContext context,
+    required bool hasResult,
+    required int? count,
+  }) {
+    return SliverAppBar(
+      toolbarHeight:
+          appTextTheme.bodySmall!.fontSize! * appTextTheme.bodySmall!.height!,
+      flexibleSpace: FlexibleSpaceBar(
+        background: hasResult
+            ? Text(
+                // TODO: <LOW> 3桁区切りにする
+                // 例) 1000000 => 1,000,000
+                '$count 件',
+                style: appTextTheme.bodySmall!.copyWith(
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+              )
+            : const SizedBox.shrink(),
+      ),
+    );
+  }
+
+  Widget _searchWindow(
     TextEditingController controller,
-    Future<void> Function() onTap,
+    FocusNode focusNode,
+    bool hasFocus,
+    Future<void> Function() onTapSearch,
+    void Function() onTapCancel,
   ) {
-    return TextField(
-      controller: controller,
-      textInputAction: TextInputAction.search,
-      onSubmitted: (_) async => await onTap(),
+    return Row(
+      children: [
+        Flexible(
+          child: TextField(
+            controller: controller,
+            focusNode: focusNode,
+            textInputAction: TextInputAction.search,
+            decoration: const InputDecoration(prefixIcon: Icon(Icons.search)),
+            onSubmitted: (_) async => await onTapSearch(),
+          ),
+        ),
+        hasFocus
+            ? InkWell(
+                borderRadius: BorderRadius.circular(Sizes.p8),
+                onTap: () => onTapCancel(),
+                child: const Padding(
+                  padding: EdgeInsets.only(
+                    left: Sizes.p8,
+                    top: Sizes.p8,
+                    bottom: Sizes.p8,
+                  ),
+                  child: Text(
+                    'Cancel',
+                    style: TextStyle(color: AppFixedColor.action),
+                  ),
+                ),
+              )
+            : const SizedBox.shrink(),
+      ],
+    );
+  }
+
+  Widget _contentDefault() {
+    return SliverList(
+      delegate: SliverChildListDelegate([
+        Text(
+          'Discover\namazing\nrepositories\non GitHub',
+          style: appTextTheme.headlineLarge,
+        )
+      ]),
+    );
+  }
+
+  Widget _contentHasResult(
+    List<Item> items,
+    void Function(BuildContext context, Item item) onTap,
+  ) {
+    return SliverList.builder(
+      itemCount: items.length,
+      itemBuilder: (BuildContext context, int index) {
+        return ItemCard(
+          item: items[index],
+          onTap: () => onTap(context, items[index]),
+        );
+      },
+    );
+  }
+
+  Widget _contentNoneResult() {
+    return SliverList(
+      delegate: SliverChildListDelegate(
+        [const Text('Your search did not match any repositories')],
+      ),
     );
   }
 }

--- a/lib/presentations/views/widgets/app_image.dart
+++ b/lib/presentations/views/widgets/app_image.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:yumemi_flutter_codecheck/constants/app_sizes.dart';
+
+class AppImage extends StatelessWidget {
+  final String path;
+  final ImageType type;
+  final double? height;
+  final double? width;
+  final BoxFit? fit;
+  const AppImage({
+    super.key,
+    required this.path,
+    required this.type,
+    this.height,
+    this.width,
+    this.fit,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return _imageWidget();
+  }
+
+  Widget _imageWidget() {
+    switch (type) {
+      case ImageType.asset:
+        return Image.asset(
+          path,
+          height: height,
+          width: width,
+          fit: fit,
+          errorBuilder: (context, object, stackTrace) {
+            return _error();
+          },
+        );
+      case ImageType.url:
+        return Image.network(
+          path,
+          height: height,
+          width: width,
+          fit: fit,
+          errorBuilder: (context, object, stackTrace) {
+            return _error();
+          },
+        );
+    }
+  }
+
+  Widget _error() {
+    return Container(
+      height: height,
+      width: width,
+      color: Colors.grey[300]!,
+      child: Icon(
+        Icons.broken_image,
+        color: Colors.grey,
+        size: (height == null && width == null)
+            ? Sizes.p20
+            : (height! >= width!)
+                ? width! / 2
+                : height! / 2,
+      ),
+    );
+  }
+}
+
+/// AppImageWidget内で画像ファイルの存在場所を明確にするための引数として利用
+/// - [asset] => アセットから画像を配置する場合
+/// - [url] => インターネット上の画像を配置する場合
+enum ImageType { asset, url }

--- a/lib/presentations/views/widgets/bottom_nav.dart
+++ b/lib/presentations/views/widgets/bottom_nav.dart
@@ -36,8 +36,6 @@ class _BottomNavigatorState extends State<BottomNavigator> {
               label: '',
             ),
           ],
-          selectedItemColor: Theme.of(context).colorScheme.primary,
-          unselectedItemColor: Theme.of(context).colorScheme.secondary,
           currentIndex: _currentIndex,
           onTap: (index) => _onTabTapped(index),
         ),

--- a/lib/presentations/views/widgets/bottom_nav.dart
+++ b/lib/presentations/views/widgets/bottom_nav.dart
@@ -28,11 +28,11 @@ class _BottomNavigatorState extends State<BottomNavigator> {
         child: BottomNavigationBar(
           items: const [
             BottomNavigationBarItem(
-              icon: Icon(Icons.home_rounded),
+              icon: Icon(Icons.search),
               label: '',
             ),
             BottomNavigationBarItem(
-              icon: Icon(Icons.favorite_rounded),
+              icon: Icon(Icons.settings),
               label: '',
             ),
           ],

--- a/lib/presentations/views/widgets/item_card.dart
+++ b/lib/presentations/views/widgets/item_card.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:yumemi_flutter_codecheck/constants/app_sizes.dart';
+import 'package:yumemi_flutter_codecheck/domain/models/item_model.dart';
+import 'package:yumemi_flutter_codecheck/presentations/views/widgets/app_image.dart';
+import 'package:yumemi_flutter_codecheck/themes/app_text_theme.dart';
+
+class ItemCard extends StatelessWidget {
+  final Item item;
+  final void Function() onTap;
+  const ItemCard({
+    super.key,
+    required this.item,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(
+          vertical: Sizes.p12,
+        ),
+        decoration: BoxDecoration(
+          border: Border(
+            bottom: BorderSide(
+              color: Theme.of(context).colorScheme.outline,
+            ),
+          ),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(12),
+                  child: AppImage(
+                    path: item.owner.avatarUrl,
+                    type: ImageType.url,
+                    height: 24,
+                  ),
+                ),
+                gapW8,
+                Text(
+                  item.name,
+                  style: appTextTheme.labelLarge,
+                ),
+              ],
+            ),
+            gapH8,
+            Text(
+              item.description ?? '-',
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/themes/app_color_scheme.dart
+++ b/lib/themes/app_color_scheme.dart
@@ -6,8 +6,8 @@ class AppColorScheme {
     brightness: Brightness.light,
     primary: Color(0xFF0B080B),
     onPrimary: Color(0xFFFFFFFF),
-    secondary: Color(0xFFCFCFCF),
-    onSecondary: Color(0xFF140F1F),
+    secondary: Color(0xFFF0F0F0),
+    onSecondary: Color(0xFF999999),
     error: AppFixedColor.error,
     onError: Color(0xFFFFFFFF),
     surface: Color(0xFFFFFFFF),
@@ -20,18 +20,20 @@ class AppColorScheme {
     brightness: Brightness.dark,
     primary: Color(0xFFFFFFFF),
     onPrimary: Color(0xFF0B080B),
-    secondary: Color(0xFF444444),
-    onSecondary: Color(0xFFFFFFFF),
+    secondary: Color(0xFF505050),
+    onSecondary: Color(0xFF999999),
     error: AppFixedColor.error,
     onError: Color(0xFFFFFFFF),
     surface: Color(0xFF0B080B),
     onSurface: Color(0xFFFFFFFF),
-    outline: Color(0xFFB0B0B0),
+    outline: Color(0xFF505050),
   );
 }
 
 /// Lightモード, Darkモードに関係なく使用されるカラーアセット
 /// - Functionalカラーなど
 class AppFixedColor {
+  static const action = Color(0xFF057CFF);
   static const error = Color(0xFFFF334B);
+  static const inactive = Color(0xFFCFCFCF);
 }

--- a/lib/themes/app_theme_data.dart
+++ b/lib/themes/app_theme_data.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:yumemi_flutter_codecheck/constants/app_sizes.dart';
 import 'package:yumemi_flutter_codecheck/themes/app_color_scheme.dart';
@@ -5,16 +6,54 @@ import 'package:yumemi_flutter_codecheck/themes/app_text_theme.dart';
 
 class AppThemeData {
   final bool isDarkMode;
+  final ColorScheme colorScheme;
 
-  AppThemeData.light() : isDarkMode = false;
-  AppThemeData.dark() : isDarkMode = true;
+  AppThemeData.light()
+      : isDarkMode = false,
+        colorScheme = AppColorScheme.light;
+
+  AppThemeData.dark()
+      : isDarkMode = true,
+        colorScheme = AppColorScheme.dark;
 
   ThemeData get themeData {
     return ThemeData(
       useMaterial3: true,
       colorScheme: isDarkMode ? AppColorScheme.dark : AppColorScheme.light,
       textTheme: appTextTheme,
-      // 以下にWidgetのThemeを追加する
+      // AppBar
+      appBarTheme: AppBarTheme(
+        titleTextStyle: appTextTheme.titleSmall,
+        elevation: 0,
+        shadowColor: Colors.transparent,
+        surfaceTintColor: Colors.transparent,
+        iconTheme: const IconThemeData(
+          size: Sizes.p20,
+        ),
+      ),
+
+      // TextField
+      inputDecorationTheme: InputDecorationTheme(
+        filled: true,
+        fillColor: colorScheme.secondary,
+        border: OutlineInputBorder(
+          borderSide: BorderSide.none,
+          borderRadius: BorderRadius.circular(Sizes.p8),
+        ),
+        prefixIconColor: colorScheme.onSecondary,
+        suffixIconColor: colorScheme.onSecondary,
+      ),
+
+      // textSelection
+      textSelectionTheme: TextSelectionThemeData(
+        cursorColor: AppFixedColor.action,
+        selectionColor: AppFixedColor.action.withOpacity(0.2),
+        selectionHandleColor: AppFixedColor.action,
+      ),
+      cupertinoOverrideTheme: const CupertinoThemeData(
+        // iOSにも適応
+        primaryColor: AppFixedColor.action,
+      ),
 
       // bottomNavigation
       bottomNavigationBarTheme: const BottomNavigationBarThemeData(
@@ -26,6 +65,8 @@ class AppThemeData {
           size: Sizes.p32,
         ),
         unselectedIconTheme: IconThemeData(size: Sizes.p32),
+        selectedItemColor: AppFixedColor.action,
+        unselectedItemColor: AppFixedColor.inactive,
       ),
     );
   }


### PR DESCRIPTION
## チケット
https://www.notion.so/UI-a43b99a0e5db4a34adafae50782aa0b6?pvs=4

## 対応内容
- Color, Themeのアップデート
- 新規Widgetの作成
  - AppImage
    - デフォルトで画像のエラーハンドリングがされている
  - ItemCard
    - リポジトリ概要を表示する
- SearchViewのModelを作成
- 検索をクリアするためのボタンを追加

## エビデンス
https://github.com/go5go69/yumemi-flutter-codecheck/assets/71274816/a360db60-9a26-4850-8d5d-bba07fc114d6
