### PR TITLE
🚑️  setting_viewのエラーを解消

### DIFF
--- a/lib/presentations/views/setting_view.dart
+++ b/lib/presentations/views/setting_view.dart
@@ -7,10 +7,7 @@ class SettingView extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return ViewTemplate.primary(
-        body: const Expanded(
-      child: Center(
-        child: Text('coming soon'),
-      ),
-    ));
+      body: const Center(child: Text('coming soon')),
+    );
   }
 }


### PR DESCRIPTION
## 概要
設定画面でWidgetのエラーが出ていたため解消

## エラー内容
```
The following assertion was thrown while applying parent data.:
Incorrect use of ParentDataWidget.
The ParentDataWidget Expanded(flex: 1) wants to apply ParentData of type FlexParentData to a RenderObject, which has been set up to accept ParentData of incompatible type BoxParentData.
Usually, this means that the Expanded widget has the wrong ancestor RenderObjectWidget. Typically, Expanded widgets are placed directly inside Flex widgets.
The offending Expanded is currently placed inside a Padding widget.
The ownership chain for the RenderObject that received the incompatible parent data was:
  Center ← Expanded ← Padding ← MediaQuery ← Padding ← SafeArea ← Listener ← _GestureSemantics ← RawGestureDetector ← GestureDetector ← ⋯

When the exception was thrown, this was the stack:
```