### PR TITLE
💄 theme,言語設定で使用してるSettingCardをアイコン非表示時もアイコンの高さを確保

### DIFF
--- a/lib/presentations/views/language_setting_view.dart
+++ b/lib/presentations/views/language_setting_view.dart
@@ -34,6 +34,8 @@ class LanguageSettingView extends ConsumerWidget {
     );
   }
 
+  /// 言語を変更するためのカード
+  /// - 設定中の言語の場合チェックが表示
   InkWell _langSettingCard(
     LangType type,
     String currentLangCode,
@@ -43,9 +45,13 @@ class LanguageSettingView extends ConsumerWidget {
       onTap: () => onTap(type),
       child: SettingCard(
         label: type.toString(),
-        suffixWidget: (currentLangCode == type.name)
-            ? const Icon(Icons.check_circle, color: AppFixedColor.action)
-            : const SizedBox.shrink(),
+        suffixWidget: Visibility(
+          visible: currentLangCode == type.name,
+          maintainState: true,
+          maintainAnimation: true,
+          maintainSize: true,
+          child: const Icon(Icons.check_circle, color: AppFixedColor.action),
+        ),
       ),
     );
   }

--- a/lib/presentations/views/mode_setting_page.dart
+++ b/lib/presentations/views/mode_setting_page.dart
@@ -43,9 +43,13 @@ class ModeSettingPage extends ConsumerWidget {
       onTap: () => onTap(type),
       child: SettingCard(
         label: type.toWord(context),
-        suffixWidget: currentType == type
-            ? const Icon(Icons.check_circle, color: AppFixedColor.action)
-            : const SizedBox.shrink(),
+        suffixWidget: Visibility(
+          visible: currentType == type,
+          maintainState: true,
+          maintainAnimation: true,
+          maintainSize: true,
+          child: const Icon(Icons.check_circle, color: AppFixedColor.action),
+        ),
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: yumemi_flutter_codecheck
 description: "A new Flutter project."
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
-version: 1.1.0
+version: 1.1.1
 
 environment:
   sdk: '>=3.4.1 <4.0.0'


### PR DESCRIPTION
Closes #20 

## 対応内容
- タイトルの通り変更
- version1.1.0 => 1.1.1に変更

## エビデンス
https://github.com/go5go69/yumemi-flutter-codecheck/assets/71274816/819a6898-2520-491b-bc86-2a5c9459f8cd

