### PR TITLE
🚀 本番環境: version1.1.2

### DIFF
--- a/.fvm/flutter_sdk
+++ b/.fvm/flutter_sdk
@@ -1,1 +1,1 @@
-/Users/go/fvm/versions/3.22.1
+/Users/go/fvm/versions/3.22.2

--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,4 +1,4 @@
 {
-  "flutterSdkVersion": "3.22.1",
+  "flutterSdkVersion": "3.22.2",
   "flavors": {}
 }

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.22.1'
+          flutter-version: '3.22.2'
 
       - name: Install dependencies
         run: flutter pub get
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.22.1'
+          flutter-version: '3.22.2'
 
       - name: Install dependencies
         run: flutter pub get

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -297,10 +297,10 @@ packages:
     dependency: "direct main"
     description:
       name: freezed_annotation
-      sha256: f54946fdb1fa7b01f780841937b1a80783a20b393485f3f6cdf336fd6f4705f2
+      sha256: f9f6597ac43cc262fa7d7f2e65259a6060c23a560525d1f2631be374540f2a9b
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.3"
   frontend_server_client:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: yumemi_flutter_codecheck
 description: "A new Flutter project."
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
-version: 1.1.1
+version: 1.1.2
 
 environment:
   sdk: '>=3.4.1 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter_riverpod: ^2.5.1
   flutter_svg: ^2.0.10+1
   freezed: ^2.5.2
-  freezed_annotation: ^2.4.2
+  freezed_annotation: ^2.4.3
   go_router: ^14.2.0
   intl: ^0.19.0
   mockito: ^5.4.4


### PR DESCRIPTION
## 概要
`develop`ブランチから`main`ブランチへのマージを行います。
Flutter SDK version を変更しました。

## 対応内容
- fvm version up: 3.22.1 => 3.22.2
  - - GitHub Actionsで使用する `flutter-version` も合わせて変更
- freezed annotation ^2.4.2 => ^2.4.3
- アプリバージョンアップ: 1.1.1 => 1.1.2

## その他
iOS, Androidともに挙動に問題がないことを確認しています。
（iOSのみ実機リリースビルドも実施）